### PR TITLE
Add basic chat server example

### DIFF
--- a/chatserver/README.md
+++ b/chatserver/README.md
@@ -1,0 +1,17 @@
+# Chat Server Example
+
+This is a minimal customer service chat server inspired by the `go-fly` project. It provides simple HTTP endpoints to send and fetch messages.
+
+## Building and Running
+
+```
+# from the chatserver directory
+go run main.go
+```
+
+The server listens on port `8080` and exposes the following endpoints:
+
+- `POST /api/message` - Send a message with JSON body `{ "sender": "name", "content": "text" }`.
+- `GET /api/messages` - Fetch all messages as JSON.
+
+This implementation keeps messages in memory and does not support authentication or persistence.

--- a/chatserver/main.go
+++ b/chatserver/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync"
+)
+
+type Message struct {
+	ID      int    `json:"id"`
+	Sender  string `json:"sender"`
+	Content string `json:"content"`
+}
+
+type ChatServer struct {
+	mu       sync.Mutex
+	messages []Message
+}
+
+func NewChatServer() *ChatServer {
+	return &ChatServer{messages: make([]Message, 0)}
+}
+
+func (s *ChatServer) postMessage(w http.ResponseWriter, r *http.Request) {
+	var msg Message
+	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	msg.ID = len(s.messages) + 1
+	s.messages = append(s.messages, msg)
+	s.mu.Unlock()
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(msg)
+}
+
+func (s *ChatServer) getMessages(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	json.NewEncoder(w).Encode(s.messages)
+}
+
+func main() {
+	srv := NewChatServer()
+
+	http.HandleFunc("/api/message", srv.postMessage)
+	http.HandleFunc("/api/messages", srv.getMessages)
+
+	log.Println("Chat server running on :8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a simple Go-based chat server for demonstration
- document how to run the server

## Testing
- `go run main.go & sleep 1; kill $!`
- `GO111MODULE=off go build`

------
https://chatgpt.com/codex/tasks/task_b_683c694418b88332abccad0dcc773cb2